### PR TITLE
scrolltoline negative value fix

### DIFF
--- a/src/ace.js
+++ b/src/ace.js
@@ -13771,7 +13771,7 @@ var VirtualRenderer = function(container, theme) {
             offset -= this.$size.scrollerHeight / 2;
 
         var initialScroll = this.scrollTop;
-        this.session.setScrollTop(offset);
+        this.session.setScrollTop(Math.abs(offset));
         if (animate !== false)
             this.animateScrolling(initialScroll, callback);
     };


### PR DESCRIPTION
The scroll top value could be negative if the current top value was less then the height of the scroller.
