### PR TITLE
Add npm support for local GH Url support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "name": "ace-builds",
-  "version": "14.10.09"
+  "version": "1.1.7"
 }


### PR DESCRIPTION
Without this:

`$ npm install git://github.com/ajaxorg/ace-builds#master` or any variant fails to retrieve.

Tested in:

``` sh-session
$ npm -v
2.1.5

$ node --version
v0.10.32
```

**NOTE**: Version probably needs to be major.minor.build as I put in the `package.json` in which ace-builds uses a date locale which defines it as dd.mm.yy which could cause havoc if this is ever published on npmjs.org itself. _(not 100% sure though)_

Let me know if you want anything else different or added as another commit in this PR.

I found your [LICENSE](https://github.com/ajaxorg/ace-builds/blob/master/LICENSE) file but I don't see a `bower.json` file to mirror for this... although maybe this is all you want to manage. :)
