### PR TITLE
Add extra monospace font for windows

### DIFF
--- a/src/ace.js
+++ b/src/ace.js
@@ -14678,7 +14678,7 @@ var EventEmitter = require("./lib/event_emitter").EventEmitter;
 var editorCss = ".ace_editor {\
 position: relative;\
 overflow: hidden;\
-font: 12px/normal 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;\
+font: 12px/normal 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'Source Code Pro', 'source-code-pro', monospace;\
 direction: ltr;\
 }\
 .ace_scroller {\


### PR DESCRIPTION
newer windows versions have renamed "source-code-pro" to "Source Code Pro".

Have seen users falling back to a proportional font (somehow the "monospace" was ignored?).
