### PR TITLE
Create bower.json with ignore listing

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+    "name": "ace-builds",
+    "version": "1.2.3",
+    "description": "Ace (Ajax.org Cloud9 Editor)",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "ignore": [
+        "demo"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ajaxorg/ace-builds.git"
+    },
+    "author": "",
+    "license": "BSD",
+    "bugs": {
+        "url": "https://github.com/ajaxorg/ace-builds/issues"
+    },
+    "homepage": "https://github.com/ajaxorg/ace-builds"
+}


### PR DESCRIPTION
I had trouble including this in a Rails project because the Rails asset pipeline would try to compile/minify the contents of the `demo` directory. Since this is not a necessary directory for deployment anyways, I thought a bower.json file was a useful thing to have anyhow, and it solves this problem for inclusion into many Rails projects. 