### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "ace-builds",
-    "version": "1.2.3",
+    "version": "1.2.6",
     "description": "Ace (Ajax.org Cloud9 Editor)",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
I keep getting this warning when running `bower install`:

```
mismatch Version declared in the json (1.2.3) is different than the resolved one (1.2.6)
```

Looks like the `bower.json` just needed updating.