### PR TITLE
Added 'main' section to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
     "name": "ace-builds",
     "version": "1.2.6",
     "description": "Ace (Ajax.org Cloud9 Editor)",
+    "main": "src-min-noconflict/ace.js",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"
     },


### PR DESCRIPTION
In order for wiredep to work correctly from external build tools, e.g. angular-ui-ace.
For reference, you can check the bower.json specification [here](https://github.com/bower/spec/blob/master/json.md).