### PR TITLE
Fixed css to run with angular-seed

### DIFF
--- a/demo/kitchen-sink/docs/css.css
+++ b/demo/kitchen-sink/docs/css.css
@@ -31,7 +31,7 @@
             */
         white-space: pre;
         display: block;
-        background: url(asdasd); "err
+        background: url(asdasd);
     }
 }
 


### PR DESCRIPTION
When using ace-builds in angular-seed it throws an error on "npm start" because of a syntax error which this commit fixes.