### PR TITLE
bower: remove version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
     "name": "ace-builds",
-    "version": "1.2.6",
     "description": "Ace (Ajax.org Cloud9 Editor)",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
> Bower depends solely on git/svn tags for version resolution (it doesn’t care what version is in bower.json, you can remove it).

https://bower.io/blog/#why-step-3