### PR TITLE
Updated ace typescript definition for TokenIterator

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -775,6 +775,17 @@ export namespace Ace {
     destroy(): void;
     setAutoScrollEditorIntoView(enable: boolean): void;
   }
+
+  export interface TokenIterator{
+    getCurrentToken():Token;
+    getCurrentTokenColumn():number;
+    getCurrentTokenRow():number;
+    getCurrentTokenPosition():Point;
+    getCurrentTokenRange():Range;
+    stepBackward():Token;
+    stepForward():Token;
+  }
+
 }
 
 export const version: string;
@@ -796,3 +807,6 @@ export const Range: {
   fromPoints(start: Ace.Point, end: Ace.Point): Ace.Range;
   comparePoints(p1: Ace.Point, p2: Ace.Point): number;
 };
+export const TokenIterator: {
+    new(session:Ace.EditSession, initialRow:number, initialColumn:number): Ace.TokenIterator;
+}


### PR DESCRIPTION
Updated ace typescript definition to add missing interface TokenIterator.
Refer: https://ace.c9.io/#nav=api&api=token_iterator

Following Import statement for TokenIterator from ace-builds is failing due to missing definition in ace.d.ts file.
`import {TokenIterator} from 'ace-builds';`

Defined the interface for TokenIterator under namespace Ace and exported a constant TokenIterator to allow user to import in any typescript file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
