### PR TITLE
Unneeded Worker blob

### DIFF
--- a/src/ace.js
+++ b/src/ace.js
@@ -19350,10 +19350,10 @@ function $workerBlob(workerUrl) {
 function createWorker(workerUrl) {
     if (typeof Worker == "undefined")
         return { postMessage: function() {}, terminate: function() {} };
-    var blob = $workerBlob(workerUrl);
+    /*var blob = $workerBlob(workerUrl);
     var URL = window.URL || window.webkitURL;
-    var blobURL = URL.createObjectURL(blob);
-    return new Worker(blobURL);
+    var blobURL = URL.createObjectURL(blob);*/
+    return new Worker(net.qualifyURL(workerUrl));
 }
 
 var WorkerClient = function(topLevelNamespaces, mod, classname, workerUrl, importScripts) {


### PR DESCRIPTION
*Issue #, if available:*

Some browsers don't allow passing blobs as Worker URL.

*Description of changes:*

Removed an unneeded step that will create a blob to load the script, instead of directly loading the script. Fixing lots of problems with browsers that don't allow Worker blobs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
