### PR TITLE
Fix: ace.d.ts param incorrectly marked required

### DIFF
--- a/ace.d.ts
+++ b/ace.d.ts
@@ -363,7 +363,7 @@ export namespace Ace {
     moduleUrl(name: string, component?: string): string;
     setModuleUrl(name: string, subst: string): string;
     loadModule(moduleName: string | [string, string],
-      onLoad: (module: any) => void): void;
+      onLoad?: (module: any) => void): void;
     init(packaged: any): any;
     defineOptions(obj: any, path: string, options: { [key: string]: any }): Config;
     resetOptions(obj: any): void;


### PR DESCRIPTION
Looking at the `loadModule` method [here](https://github.com/ajaxorg/ace/blob/94422a4a892495564c56089af85019a8f8f24673/lib/ace/config.js#L111-L139), we can see that `onLoad` is _only_ invoked when non-null, so it is not actually a required param.
https://github.com/ajaxorg/ace/blob/94422a4a892495564c56089af85019a8f8f24673/lib/ace/config.js#L111-L139
