### PR TITLE
Update example links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ it contains 4 versions
 
 
 For a simple way of embedding ace into webpage see [editor.html](https://github.com/ajaxorg/ace-builds/blob/master/editor.html) or list of other [simple examples](https://github.com/ajaxorg/ace-builds/tree/master/demo)
-To see ace in action go to [kitchen-sink-demo](http://ajaxorg.github.com/ace-builds/kitchen-sink.html), [scrollable-page-demo](http://ajaxorg.github.com/ace-builds/demo/scrollable-page.html) or [minimal demo](http://ajaxorg.github.com/ace-builds/editor.html),
+To see ace in action go to [kitchen-sink-demo](http://ajaxorg.github.io/ace-builds/kitchen-sink.html), [scrollable-page-demo](http://ajaxorg.github.io/ace-builds/demo/scrollable-page.html) or [minimal demo](http://ajaxorg.github.io/ace-builds/editor.html),
 
 


### PR DESCRIPTION
Changed ajaxorg.github.com to ajaxorg.github.io so the links work.

<!--
Most of the files here are generated with a build script, so You probably
should submit your pull request to https://github.com/ajaxorg/ace instead
-->

*Description of changes:*

The previous GitHub.com example links weren't working as GitHub deprecated username.github.com for GitHub Pages sites. They have been updated to username.github.io links

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
